### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
         os: [ubuntu-latest]
         python: [3.9, "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Create virtualenv
         run: python3 -m venv venv
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: venv/
           key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}


### PR DESCRIPTION
This avoids deprecation of Node 12 (which Actions warn about already) and Note 16 which is likely to come soon given that it is now also beyond end of life.