### PR TITLE
Drop redundant virtualenv we're not using

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Create virtualenv
-        run: python3 -m venv venv
-
-      - uses: actions/cache@v3
-        with:
-          path: venv/
-          key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-
-      - name: Use virtualenv
-        run: source venv/bin/activate
-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
 


### PR DESCRIPTION
I'm guessing the expectation here was that sourceing the virtualenv would persist, however that's not how Github Actions works. As is therefore working fine without a virtualenv, drop the redundant work.

Builds on #64 to avoid conflicts.