### PR TITLE
Add pit location filter

### DIFF
--- a/helpdesk/helpdesk/utils.py
+++ b/helpdesk/helpdesk/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, TypeVar
 
 from django.db.models import Model
+from django_filters import FilterSet
 
 ModelT = TypeVar("ModelT", bound=Model)
 
@@ -12,3 +13,11 @@ def get_object_or_none(model: type[ModelT], **kwargs: Any) -> ModelT | None:
         return model.objects.get(**kwargs)  # type: ignore[attr-defined]
     except model.DoesNotExist:  # type: ignore[attr-defined]
         return None
+
+
+def is_filterset_filtered(filterset: FilterSet) -> bool:
+    """
+    Determine whether a filterset has active filtered,
+    without performing a query.
+    """
+    return str(filterset.qs.query) != str(filterset.queryset.query)

--- a/helpdesk/teams/views.py
+++ b/helpdesk/teams/views.py
@@ -13,6 +13,7 @@ from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin
 
 from helpdesk.forms import CommentSubmitForm
+from helpdesk.utils import is_filterset_filtered
 from tickets.filters import TicketFilter
 from tickets.models import Ticket, TicketEvent
 from tickets.tables import TicketTable
@@ -31,6 +32,11 @@ class TeamListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     model = Team
     table_class = TeamTable
     filterset_class = TeamFilterset
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["is_filtered"] = is_filterset_filtered(self.filterset)
+        return context
 
 
 class TeamDetailAboutView(LoginRequiredMixin, DetailView):

--- a/helpdesk/templates/teams/team_filter.html
+++ b/helpdesk/templates/teams/team_filter.html
@@ -2,8 +2,8 @@
 {% load render_table from django_tables2 %}
 {% load crispy_forms_tags %}
 
-{% block page_title %}Teams{% endblock %}
-{% block title %}Teams{% endblock %}
+{% block page_title %}Teams {% if is_filtered %}<span class="is-size-5">(filtered)</span>{% endif %}{% endblock %}
+{% block title %}Teams {% if is_filtered %}(filtered){% endif %}{% endblock %}
 
 {% block page_buttons %}
     <button class="button is-warning js-modal-trigger" data-target="modal-filter">Filter</button>

--- a/helpdesk/templates/tickets/ticketqueue_assigned.html
+++ b/helpdesk/templates/tickets/ticketqueue_assigned.html
@@ -1,8 +1,8 @@
 {% extends "layouts/base_app.html" %}
 {% load render_table from django_tables2 %}
 
-{% block page_title %}My Tickets{% endblock %}
-{% block title %}My Tickets{% endblock %}
+{% block page_title %}My Tickets {% if is_filtered %}<span class="is-size-5">(filtered)</span>{% endif %}{% endblock %}
+{% block title %}My Tickets {% if is_filtered %}(filtered){% endif %}{% endblock %}
 
 {% block page_buttons %}
   <button class="button is-warning js-modal-trigger" data-target="modal-filter">Filter</button>

--- a/helpdesk/templates/tickets/tickets_all.html
+++ b/helpdesk/templates/tickets/tickets_all.html
@@ -1,8 +1,8 @@
 {% extends "layouts/base_app.html" %}
 {% load render_table from django_tables2 %}
 
-{% block page_title %}All Tickets{% endblock %}
-{% block title %}All Tickets{% endblock %}
+{% block page_title %}All Tickets {% if is_filtered %}<span class="is-size-5">(filtered)</span>{% endif %}{% endblock %}
+{% block title %}All Tickets {% if is_filtered %}(filtered){% endif %}{% endblock %}
 
 {% block page_buttons %}
   <button class="button is-warning js-modal-trigger" data-target="modal-filter">Filter</button>

--- a/helpdesk/tickets/filters.py
+++ b/helpdesk/tickets/filters.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import django_filters
 
-from teams.models import Team
+from teams.models import Team, TeamPitLocation
 
 from .models import Ticket, TicketQueue, TicketStatus
 
@@ -30,6 +30,10 @@ class TicketFilter(django_filters.FilterSet):
         queryset=Team.objects.all(),
         field_name="team",
         to_field_name="tla",
+    )
+    team__pit_location = django_filters.ModelChoiceFilter(
+        label="Pit location",
+        queryset=TeamPitLocation.objects.all(),
     )
 
     class Meta:

--- a/helpdesk/tickets/views.py
+++ b/helpdesk/tickets/views.py
@@ -13,7 +13,7 @@ from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin
 
 from helpdesk.forms import CommentSubmitForm
-from helpdesk.utils import get_object_or_none
+from helpdesk.utils import get_object_or_none, is_filterset_filtered
 from teams.models import Team
 
 from .filters import TicketFilter
@@ -75,6 +75,7 @@ class AssignedTicketListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["ticket_queues"] = TicketQueue.objects.all()
+        context["is_filtered"] = is_filterset_filtered(self.filterset)
         return context
 
 
@@ -83,6 +84,11 @@ class TicketListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     table_class = TicketTable
     template_name = "tickets/tickets_all.html"
     queryset = Ticket.objects.with_event_fields().all()
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["is_filtered"] = is_filterset_filtered(self.filterset)
+        return context
 
 
 class TicketDetailView(LoginRequiredMixin, DetailView):


### PR DESCRIPTION
With multiple helpdesks, it'd be quite useful to be able to easily filter by team location.

Note: The dropdown of teams isn't filtered by this option, so it's possible filter by a team, but with the wrong location. We might be able to add some validation around this if it becomes an issue.


![image](https://github.com/srobo/helpdesk-system/assets/6527489/8427ba5e-958f-418f-ae4d-3840626caf53)


![image](https://github.com/srobo/helpdesk-system/assets/6527489/27b56a33-e27c-45a4-9759-b256af218083)
