### PR TITLE
Bump dependencies

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,6 @@ pip-tools
 -r requirements.txt
 djhtml
 ruff
-isort
 pytest
 pytest-cov
 pytest-django
@@ -14,6 +13,3 @@ django-filter-stubs
 types-cachetools
 types-dj-database-url
 types-setuptools
-
-faker
-freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,30 +8,31 @@ asgiref==3.8.1
     # via
     #   -r requirements.txt
     #   django
-build==1.2.1
+    #   django-stubs
+build==1.2.2.post1
     # via pip-tools
-cachetools==5.3.3
+cachetools==5.5.2
     # via -r requirements.txt
-certifi==2024.7.4
+certifi==2025.1.31
     # via
     #   -r requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r requirements.txt
     #   cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via
     #   -r requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via pip-tools
-coverage[toml]==7.4.4
+coverage[toml]==7.7.1
     # via pytest-cov
 crispy-bulma==0.11.0
     # via -r requirements.txt
-cryptography==42.0.5
+cryptography==44.0.2
     # via
     #   -r requirements.txt
     #   pyjwt
@@ -39,7 +40,7 @@ defusedxml==0.7.1
     # via
     #   -r requirements.txt
     #   python3-openid
-django==4.2.11
+django==4.2.20
     # via
     #   -r requirements.txt
     #   crispy-bulma
@@ -53,48 +54,42 @@ django==4.2.11
     #   sentry-sdk
 django-allauth==0.61.1
     # via -r requirements.txt
-django-crispy-forms==2.1
+django-crispy-forms==2.3
     # via
     #   -r requirements.txt
     #   crispy-bulma
 django-environ==0.12.0
     # via -r requirements.txt
-django-filter==24.2
+django-filter==25.1
     # via -r requirements.txt
 django-filter-stubs==0.1.3
     # via -r requirements-dev.in
-django-stubs[compatible-mypy]==4.2.7
+django-stubs[compatible-mypy]==5.1.3
     # via
     #   -r requirements-dev.in
     #   django-filter-stubs
     #   djangorestframework-stubs
-django-stubs-ext==4.2.7
+django-stubs-ext==5.1.3
     # via
     #   -r requirements.txt
     #   django-stubs
-django-tables2==2.7.0
+django-tables2==2.7.5
     # via
     #   -r requirements.txt
     #   django-tables2-bulma-template
 django-tables2-bulma-template==0.2.0
     # via -r requirements.txt
-djangorestframework-stubs==3.14.5
+djangorestframework-stubs==3.15.3
     # via django-filter-stubs
-djhtml==3.0.6
+djhtml==3.0.7
     # via -r requirements-dev.in
-faker==24.7.1
-    # via -r requirements-dev.in
-freezegun==1.4.0
-    # via -r requirements-dev.in
-idna==3.7
+idna==3.10
     # via
     #   -r requirements.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-isort==5.13.2
-    # via -r requirements-dev.in
-mypy==1.7.1
+mypy==1.15.0
     # via
     #   -r requirements-dev.in
     #   django-filter-stubs
@@ -105,44 +100,40 @@ oauthlib==3.2.2
     # via
     #   -r requirements.txt
     #   requests-oauthlib
-packaging==24.0
+packaging==24.2
     # via
     #   build
     #   pytest
 pip-tools==7.4.1
     # via -r requirements-dev.in
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 pycparser==2.22
     # via
     #   -r requirements.txt
     #   cffi
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.10.1
     # via
     #   -r requirements.txt
     #   django-allauth
-pyproject-hooks==1.0.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.1.1
+pytest==8.3.5
     # via
     #   -r requirements-dev.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements-dev.in
-pytest-django==4.8.0
+pytest-django==4.10.0
     # via -r requirements-dev.in
-python-dateutil==2.9.0.post0
-    # via
-    #   faker
-    #   freezegun
 python3-openid==3.2.0
     # via
     #   -r requirements.txt
     #   django-allauth
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.txt
     #   django-allauth
@@ -152,31 +143,27 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements.txt
     #   django-allauth
-ruff==0.3.5
+ruff==0.11.2
     # via -r requirements-dev.in
-sentry-sdk[django]==2.19.2
+sentry-sdk[django]==2.24.0
     # via -r requirements.txt
-six==1.16.0
-    # via python-dateutil
-sqlparse==0.5.0
+sqlparse==0.5.3
     # via
     #   -r requirements.txt
     #   django
-types-cachetools==5.3.0.7
+types-cachetools==5.5.0.20240820
     # via -r requirements-dev.in
 types-dj-database-url==1.3.0.4
     # via -r requirements-dev.in
-types-pytz==2024.1.0.20240203
-    # via django-stubs
-types-pyyaml==6.0.12.20240311
+types-pyyaml==6.0.12.20241230
     # via
     #   django-stubs
     #   djangorestframework-stubs
-types-requests==2.31.0.20240403
+types-requests==2.32.0.20250306
     # via djangorestframework-stubs
-types-setuptools==69.2.0.20240317
+types-setuptools==76.0.0.20250313
     # via -r requirements-dev.in
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -r requirements.txt
     #   django-filter-stubs
@@ -184,13 +171,13 @@ typing-extensions==4.11.0
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   mypy
-urllib3==2.2.2
+urllib3==2.3.0
     # via
     #   -r requirements.txt
     #   requests
     #   sentry-sdk
     #   types-requests
-wheel==0.43.0
+wheel==0.45.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,23 +6,23 @@
 #
 asgiref==3.8.1
     # via django
-cachetools==5.3.3
+cachetools==5.5.2
     # via -r requirements.in
-certifi==2024.7.4
+certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
 crispy-bulma==0.11.0
     # via -r requirements.in
-cryptography==42.0.5
+cryptography==44.0.2
     # via pyjwt
 defusedxml==0.7.1
     # via python3-openid
-django==4.2.11
+django==4.2.20
     # via
     #   -r requirements.in
     #   crispy-bulma
@@ -35,46 +35,46 @@ django==4.2.11
     #   sentry-sdk
 django-allauth==0.61.1
     # via -r requirements.in
-django-crispy-forms==2.1
+django-crispy-forms==2.3
     # via
     #   -r requirements.in
     #   crispy-bulma
 django-environ==0.12.0
     # via -r requirements.in
-django-filter==24.2
+django-filter==25.1
     # via -r requirements.in
-django-stubs-ext==4.2.7
+django-stubs-ext==5.1.3
     # via -r requirements.in
-django-tables2==2.7.0
+django-tables2==2.7.5
     # via
     #   -r requirements.in
     #   django-tables2-bulma-template
 django-tables2-bulma-template==0.2.0
     # via -r requirements.in
-idna==3.7
+idna==3.10
     # via requests
 oauthlib==3.2.2
     # via requests-oauthlib
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.10.1
     # via django-allauth
 python3-openid==3.2.0
     # via django-allauth
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   django-allauth
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via django-allauth
-sentry-sdk[django]==2.19.2
+sentry-sdk[django]==2.24.0
     # via -r requirements.in
-sqlparse==0.5.0
+sqlparse==0.5.3
     # via django
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via django-stubs-ext
-urllib3==2.2.2
+urllib3==2.3.0
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
Bump all dependencies.

`django-allauth` is intentionally not upgraded, since it requires more testing. The current version should still work, as it's only small changes to the Django version (same minor version).

Also removed some dependencies which aren't actually used.