### PR TITLE
Fix env var location

### DIFF
--- a/helpdesk/helpdesk/settings.py
+++ b/helpdesk/helpdesk/settings.py
@@ -7,7 +7,6 @@ from environ import Env
 
 django_stubs_ext.monkeypatch()
 
-Env.read_env()
 
 env = Env(
     DEBUG=(bool, True),
@@ -28,6 +27,9 @@ HOSTNAME = platform.node()
 
 # Set the base directory two levels up
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Read environment variables file from the repository root.
+Env.read_env(BASE_DIR.parent / ".env")
 
 sentry_sdk.init(
     dsn=env("SENTRY_DSN"),

--- a/helpdesk/helpdesk/settings.py
+++ b/helpdesk/helpdesk/settings.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 import django_stubs_ext
 import sentry_sdk
-from environ import Env
+from environ import FileAwareEnv
 
 django_stubs_ext.monkeypatch()
 
 
-env = Env(
+env = FileAwareEnv(
     DEBUG=(bool, True),
     SENTRY_DSN=(str, ""),
     ALLOWED_HOSTS=(list, ["*"]),
@@ -29,7 +29,7 @@ HOSTNAME = platform.node()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Read environment variables file from the repository root.
-Env.read_env(BASE_DIR.parent / ".env")
+env.read_env(BASE_DIR.parent / ".env")
 
 sentry_sdk.init(
     dsn=env("SENTRY_DSN"),


### PR DESCRIPTION
2 changes:

- Explicitly define `.env` file location, rather than let it be implied (incorrectly).
- Use a file-aware env reader, so `_FILE` suffixed variables can read files. This is mostly useful to avoid some hacks in the Ansible deployment.